### PR TITLE
Loosen constraint on http

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   collection: '^1.9.0'
-  http: '^0.11.0'
+  http: '>=0.11.0 <0.13.0'
   package_config: '>=0.1.0 <2.0.0'
   path: '^1.0.0'
 dev_dependencies:


### PR DESCRIPTION
Allows `http: 0.12.0-dev` to use `test`.