### PR TITLE
Remove upper case constants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: dart
 
 dart:
   - dev
-  - stable
-
 dart_task:
   - test: --platform vm
   - test: --platform firefox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.3
+
+* Update SDK version.
+* Stop using deprecated UTF8 constant.
+
 ## 1.0.2
 
 * Don't crash on URIs without path components.

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -35,7 +35,7 @@ Future<Map<String, Uri>> loadConfigMap(Uri uri, {http.Client client}) async {
         'PackageInfo.loadConfig doesn\'t support URI scheme "${uri.scheme}:".');
   }
 
-  return packages_file.parse(UTF8.encode(text), resolved);
+  return packages_file.parse(utf8.encode(text), resolved);
 }
 
 /// Converts [uri] to a [Uri] and verifies that it's a valid `package:` URI.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: package_resolver
-version: 1.0.3-dev
+version: 1.0.3
 description: First-class package resolution strategy classes.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/package_resolver
 
 environment:
-  sdk: '>=1.14.0 <2.0.0'
+  sdk: '>=2.0.0-dev.17.0 <2.0.0'
 
 dependencies:
   collection: '^1.9.0'
@@ -15,3 +15,4 @@ dependencies:
 dev_dependencies:
   shelf: '^0.6.0'
   test: '^0.12.0'
+  stack_trace: '^1.9.2'


### PR DESCRIPTION
Update SDK version and package version to be ready to publish.

Add dev-dependency directly on stack_trace package.
Imported the package, but relied on an indirect dependency to ensure that the package was available.