### PR TITLE
support package:http version 0.12.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.6
+
+* Support package:http version `0.12.x`.
+
 ## 1.0.5
 
 * Use conditional imports to avoid dart:io imports on the web.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: package_resolver
-version: 1.0.5
+version: 1.0.6
 
 description: First-class package resolution strategy classes.
 author: Dart Team <misc@dartlang.org>
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   collection: ^1.9.0
-  http: ^0.11.0
+  http: ">0.11.0 <0.13.0"
   package_config: '>=0.1.0 <2.0.0'
   path: ^1.0.0
 


### PR DESCRIPTION
need this to actually publish package:http (its only a transitive dev dependency there but we can't publish it with dependency overrides)