### PR TITLE
Use conditional imports for `dart:isolate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
+## 1.0.7
+
+* Use conditional imports to avoid `dart:isolate` imports on the web.
+
 ## 1.0.6
 
 * Support package:http version `0.12.x`.
 
 ## 1.0.5
 
-* Use conditional imports to avoid dart:io imports on the web.
+* Use conditional imports to avoid `dart:io` imports on the web.
 
 ## 1.0.4
 

--- a/lib/src/current_isolate_resolver.dart
+++ b/lib/src/current_isolate_resolver.dart
@@ -14,7 +14,9 @@ import 'sync_package_resolver.dart';
 import 'utils.dart';
 
 /// The package resolution strategy used by the current isolate.
-class CurrentIsolateResolver implements PackageResolver {
+PackageResolver currentIsolateResolver() => _CurrentIsolateResolver();
+
+class _CurrentIsolateResolver implements PackageResolver {
   Future<Map<String, Uri>> get packageConfigMap async {
     if (_packageConfigMap != null) return _packageConfigMap;
 

--- a/lib/src/current_isolate_resolver_stub.dart
+++ b/lib/src/current_isolate_resolver_stub.dart
@@ -1,0 +1,8 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package_resolver.dart';
+
+PackageResolver currentIsolateResolver() =>
+    throw UnsupportedError('No current isolate support on this platform');

--- a/lib/src/package_resolver.dart
+++ b/lib/src/package_resolver.dart
@@ -6,10 +6,14 @@ import 'dart:async';
 
 import 'package:http/http.dart' as http;
 
-import 'current_isolate_resolver.dart';
 import 'package_config_resolver.dart';
 import 'package_root_resolver.dart';
 import 'sync_package_resolver.dart';
+
+// ignore: uri_does_not_exist
+import 'current_isolate_resolver_stub.dart'
+    // ignore: uri_does_not_exist
+    if (dart.library.isolate) 'current_isolate_resolver.dart' as isolate;
 
 /// A class that defines how to resolve `package:` URIs.
 ///
@@ -81,7 +85,7 @@ abstract class PackageResolver {
 
   /// Returns package resolution strategy describing how the current isolate
   /// resolves `package:` URIs.
-  static final PackageResolver current = new CurrentIsolateResolver();
+  static final PackageResolver current = isolate.currentIsolateResolver();
 
   /// Returns a package resolution strategy that is unable to resolve any
   /// `package:` URIs.

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -2,19 +2,20 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// TODO(nweiz): Avoid importing dart:io directly when cross-platform libraries
-// exist.
 import 'dart:async';
 import 'dart:convert';
-import 'dart:isolate';
 
 import 'package:http/http.dart' as http;
 import 'package:package_config/packages_file.dart' as packages_file;
 
 // ignore: uri_does_not_exist
-import 'utils_stub.dart'
+import 'utils_io_stub.dart'
     // ignore: uri_does_not_exist
-    if (dart.library.io) 'utils_io.dart' as conditional;
+    if (dart.library.io) 'utils_io.dart' as io;
+// ignore: uri_does_not_exist
+import 'utils_isolate_stub.dart'
+    // ignore: uri_does_not_exist
+    if (dart.library.isolate) 'utils_isolate.dart' as isolate;
 
 /// Loads the configuration map from [uri].
 ///
@@ -28,11 +29,11 @@ Future<Map<String, Uri>> loadConfigMap(Uri uri, {http.Client client}) async {
   if (resolved.scheme == 'http') {
     text = await (client == null ? http.read(resolved) : client.read(resolved));
   } else if (resolved.scheme == 'file') {
-    text = await conditional.readFileAsString(resolved);
+    text = await io.readFileAsString(resolved);
   } else if (resolved.scheme == 'data') {
     text = resolved.data.contentAsString();
   } else if (resolved.scheme == 'package') {
-    return loadConfigMap(await Isolate.resolvePackageUri(uri), client: client);
+    return loadConfigMap(await isolate.resolvePackageUri(uri), client: client);
   } else {
     throw new UnsupportedError(
         'PackageInfo.loadConfig doesn\'t support URI scheme "${uri.scheme}:".');
@@ -83,4 +84,4 @@ Uri ensureTrailingSlash(Uri uri) {
 }
 
 String packagePathForRoot(String package, Uri root) =>
-    conditional.packagePathForRoot(package, root);
+    io.packagePathForRoot(package, root);

--- a/lib/src/utils_io_stub.dart
+++ b/lib/src/utils_io_stub.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+Future<String> readFileAsString(Uri uri) => throw UnsupportedError(
+    'Reading files is only supported where dart:io is available.');
+
+String packagePathForRoot(String package, Uri root) => throw UnsupportedError(
+    'Computing package paths from a root is only supported where dart:io is '
+    'available.');

--- a/lib/src/utils_isolate.dart
+++ b/lib/src/utils_isolate.dart
@@ -1,0 +1,8 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:isolate';
+
+Future<Uri> resolvePackageUri(Uri packageUri) =>
+    Isolate.resolvePackageUri(packageUri);

--- a/lib/src/utils_isolate_stub.dart
+++ b/lib/src/utils_isolate_stub.dart
@@ -1,0 +1,6 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+Future<Uri> resolvePackageUri(Uri packageUri) =>
+    throw UnsupportedError('May not use a package URI');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: package_resolver
-version: 1.0.6
+version: 1.0.7
 
 description: First-class package resolution strategy classes.
 author: Dart Team <misc@dartlang.org>


### PR DESCRIPTION
This is specified as not existing on the web platforms, although in
practice it can be imported an at least one API works on DDC but not
dart2js. Since this may become more strict, use conditional imports with
an explicitly non-working fallback when `dart:isolate` is not available.

- Make `CurrentIsolateResolver` private and add a top level method
  instead since it is easier to stub.
- Rename `util_stub.dart` to `util_io_sub.dart` to avoid confusion
  against the new `util_isolate_stub.dart`.