### PR TITLE
Prepare to republish as 1.0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: dart
 dart:
   - dev
   - stable
-  - 2.0.0
 
 dart_task:
   - test: --platform vm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.0.10
+
+* Use conditional imports to avoid `dart:isolate` imports on the web.
+* Bump minimum SDK to `2.1.0`.
+
+## 1.0.9
+
+* Identical to `1.0.6` - republishing with a higher version number to get around
+  issues with conditional `dart:isolate` imports on the version of
+  `build_modules` which is compatible with the `2.0.0` SDK.
+
 ## 1.0.8
 
 * Fix issue on Dart `2.0.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 1.0.9
+
+* Identical to `1.0.6` - republishing with a higher version number to get around
+  issues with conditional `dart:isolate` imports on the version of
+  `build_modules` which is compatible with the `2.0.0` SDK.
+
+## 1.0.8
+
+* Fix issue on Dart `2.0.0`.
+
+## 1.0.7
+
+* Use conditional imports to avoid `dart:isolate` imports on the web.
+
 ## 1.0.6
 
 * Support package:http version `0.12.x`.

--- a/lib/src/async_package_resolver.dart
+++ b/lib/src/async_package_resolver.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package_resolver.dart';
 import 'sync_package_resolver.dart';
 

--- a/lib/src/current_isolate_resolver.dart
+++ b/lib/src/current_isolate_resolver.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:isolate';
 
 import 'package:path/path.dart' as p;

--- a/lib/src/package_resolver.dart
+++ b/lib/src/package_resolver.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:http/http.dart' as http;
 
 import 'package_config_resolver.dart';

--- a/lib/src/sync_package_resolver.dart
+++ b/lib/src/sync_package_resolver.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:http/http.dart' as http;
 
 import 'no_package_resolver.dart';

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;

--- a/lib/src/utils_io.dart
+++ b/lib/src/utils_io.dart
@@ -2,14 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
-Future<String> readFileAsString(Uri uri) async {
+Future<String> readFileAsString(Uri uri) {
   var path = uri.toFilePath(windows: Platform.isWindows);
-  return await new File(path).readAsString();
+  return new File(path).readAsString();
 }
 
 String packagePathForRoot(String package, Uri root) {

--- a/lib/src/utils_io_stub.dart
+++ b/lib/src/utils_io_stub.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 Future<String> readFileAsString(Uri uri) => throw UnsupportedError(
     'Reading files is only supported where dart:io is available.');
 

--- a/lib/src/utils_isolate.dart
+++ b/lib/src/utils_isolate.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:isolate';
 
 Future<Uri> resolvePackageUri(Uri packageUri) =>

--- a/lib/src/utils_isolate_stub.dart
+++ b/lib/src/utils_isolate_stub.dart
@@ -2,7 +2,5 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 Future<Uri> resolvePackageUri(Uri packageUri) =>
     throw UnsupportedError('May not use a package URI');

--- a/lib/src/utils_stub.dart
+++ b/lib/src/utils_stub.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 Future<String> readFileAsString(Uri uri) => throw UnsupportedError(
     'Reading files is only supported where dart:io is available.');
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: package_resolver
-version: 1.0.8
+version: 1.0.10
 
 description: First-class package resolution strategy classes.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/package_resolver
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
   collection: ^1.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: package_resolver
-version: 1.0.6
+version: 1.0.9
 
 description: First-class package resolution strategy classes.
 author: Dart Team <misc@dartlang.org>

--- a/test/current_isolate_info_test.dart
+++ b/test/current_isolate_info_test.dart
@@ -4,7 +4,6 @@
 
 @TestOn('vm')
 
-import 'dart:async';
 import 'dart:io';
 import 'dart:isolate';
 


### PR DESCRIPTION
- Bump minimum SDK constraint to one that includes `Future` in
  `dart:core`.
- Remove all `dart:async` imports which are no longer required.
- Merge in branch that published as 1.0.9 to include changelog.